### PR TITLE
Tweak the pure label:after styling for non white backgrounds

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
             }
         </script>
     </head>
-    <body>
+    <body style="background-color:#ddd;">
         <pure-form src="schemas/space-camp-application.json" validate-on-blur="true" auto-resize="true"></pure-form>
     </body>
 </html>

--- a/src/pure-form.css
+++ b/src/pure-form.css
@@ -80,11 +80,12 @@ pure-form .pure-form-label[data-characters-remaining]:after {
     font-size: 12px;
     position: absolute;
     right: 10px;
-    top: -8px;
-    padding: 0 8px;
-    border-radius: 2px;
+    top: -10px;
+    padding: 2px 8px;
+    border-radius: 8px;
     background: #fff;
     text-transform: lowercase;
+    border: 1px solid #ddd;
 }
 
 
@@ -247,5 +248,6 @@ pure-form ::-moz-placeholder  { font-size: 14px; }
         clear: both;
         float: none;
         display: block;
+        background-color: transparent;
     }
 }


### PR DESCRIPTION
When the form’s background is non-white, the existing label doesn’t look so good. So putting forward a slight style tweak that works for all background colours.